### PR TITLE
Add vm filtering by keywords

### DIFF
--- a/src/app/pages/machines/machines.list.html
+++ b/src/app/pages/machines/machines.list.html
@@ -3,6 +3,16 @@
     Virtual Machines List
   </nb-card-header>
   <nb-card-body>
-    <ng2-smart-table [settings]="settings" [source]="source"></ng2-smart-table>
+    <div class='form-inline input-group mb-2'>
+      <label for='keywordSearch' class='form-control-label input-group-addon'>
+        Keywords:
+      </label>
+      <input id='keywordSearch'
+             class='form-control full-width'
+             [formControl]='keywordSearchControl'
+             type='text'
+             placeholder='win7,true,intellij'>
+    </div>
+    <ng2-smart-table [settings]='settings' [source]='source'></ng2-smart-table>
   </nb-card-body>
 </nb-card>


### PR DESCRIPTION
The original ticket required filtering vms based on tags from
vm description. As it turns out, ng2-smart-table that we use
supports custom edit and render cell components, but not
filter components.

Instead of manually patching the table, I opted for a global
keyword search on all fields which uses existing table filtering
capabilities. You can use the "old" filtering on top of that too.